### PR TITLE
Make Windows default configuration build shared library 

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Cross-platform access library for Intel(R) CSME HECI interface.
 ## CMake Build
 
 ME TEE library uses CMake for both Linux and Windows builds.
+Adapted to work with managed code: C# and Python
 
 ### Windows
 

--- a/win32.cmake
+++ b/win32.cmake
@@ -6,7 +6,7 @@ set(TEE_SOURCES
     src/Windows/metee_winhelpers.c
 )
 
-add_library(${PROJECT_NAME} ${TEE_SOURCES})
+add_library(${PROJECT_NAME} SHARED ${TEE_SOURCES})
 
 if(BUILD_MSVC_RUNTIME_STATIC)
   target_compile_options(${PROJECT_NAME} PRIVATE /MT$<$<CONFIG:Debug>:d>)


### PR DESCRIPTION
This is required in order to use metee with C# / Python