### PR TITLE
Disable HTML timestamps in Doxygen

### DIFF
--- a/include/Doxyfile.in
+++ b/include/Doxyfile.in
@@ -1281,7 +1281,7 @@ HTML_COLORSTYLE_GAMMA  = 80
 # The default value is: NO.
 # This tag requires that the tag GENERATE_HTML is set to YES.
 
-HTML_TIMESTAMP         = YES
+HTML_TIMESTAMP         = NO
 
 # If the HTML_DYNAMIC_MENUS tag is set to YES then the generated HTML
 # documentation will contain a main index with vertical navigation menus that


### PR DESCRIPTION
Fedora rpmlint test is failing because if this:

intel-metee-doc.noarch: E: file-contains-date-and-time /usr/share/doc/metee/html/annotated.html
intel-metee-doc.noarch: E: file-contains-date-and-time /usr/share/doc/metee/html/classes.html
intel-metee-doc.noarch: E: file-contains-date-and-time /usr/share/doc/metee/html/dir_d44c64559bbebec7f509842c48db8b23.html
intel-metee-doc.noarch: E: file-contains-date-and-time /usr/share/doc/metee/html/files.html
intel-metee-doc.noarch: E: file-contains-date-and-time /usr/share/doc/metee/html/functions.html
intel-metee-doc.noarch: E: file-contains-date-and-time /usr/share/doc/metee/html/functions_vars.html
intel-metee-doc.noarch: E: file-contains-date-and-time /usr/share/doc/metee/html/globals.html
intel-metee-doc.noarch: E: file-contains-date-and-time /usr/share/doc/metee/html/globals_defs.html
intel-metee-doc.noarch: E: file-contains-date-and-time /usr/share/doc/metee/html/globals_enum.html
intel-metee-doc.noarch: E: file-contains-date-and-time /usr/share/doc/metee/html/globals_eval.html
intel-metee-doc.noarch: E: file-contains-date-and-time /usr/share/doc/metee/html/globals_func.html
intel-metee-doc.noarch: E: file-contains-date-and-time /usr/share/doc/metee/html/globals_type.html
intel-metee-doc.noarch: E: file-contains-date-and-time /usr/share/doc/metee/html/index.html
intel-metee-doc.noarch: E: file-contains-date-and-time /usr/share/doc/metee/html/metee_8h.html
intel-metee-doc.noarch: E: file-contains-date-and-time /usr/share/doc/metee/html/metee_8h_source.html
intel-metee-doc.noarch: E: file-contains-date-and-time /usr/share/doc/metee/html/struct__TEEHANDLE.html
intel-metee-doc.noarch: E: file-contains-date-and-time /usr/share/doc/metee/html/structteeDriverVersion__t.html