### PR TITLE
MeTee: linux: Include poll.h instead of sys/poll.h 

### DIFF
--- a/src/linux/metee_linux.c
+++ b/src/linux/metee_linux.c
@@ -12,7 +12,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <sys/ioctl.h>
-#include <sys/poll.h>
+#include <poll.h>
 #include <unistd.h>
 
 #include "metee.h"


### PR DESCRIPTION
fix compilation error with musl C library:

 error: #warning redirecting incorrect #include <sys/poll.h> to <poll.h>