### PR TITLE
Fix sign-conversion warnings with musl ioctl

### DIFF
--- a/src/linux/mei.c
+++ b/src/linux/mei.c
@@ -197,7 +197,7 @@ static inline int __mei_connect(struct mei *me, struct mei_connect_client_data *
 	int rc;
 
 	errno = 0;
-	rc = ioctl(me->fd, IOCTL_MEI_CONNECT_CLIENT, d);
+	rc = ioctl(me->fd, (int)IOCTL_MEI_CONNECT_CLIENT, d);
 	me->last_err = errno;
 	return rc == -1 ? -me->last_err : 0;
 }
@@ -208,7 +208,7 @@ static inline int __mei_connect_vtag(struct mei *me,
 	int rc;
 
 	errno = 0;
-	rc = ioctl(me->fd, IOCTL_MEI_CONNECT_CLIENT_VTAG, d);
+	rc = ioctl(me->fd, (int)IOCTL_MEI_CONNECT_CLIENT_VTAG, d);
 	me->last_err = errno;
 	return rc == -1 ? -me->last_err : 0;
 }
@@ -229,7 +229,7 @@ static inline int __mei_notify_get(struct mei *me)
 	int rc;
 
 	errno = 0;
-	rc = ioctl(me->fd, IOCTL_MEI_NOTIFY_GET, &notification);
+	rc = ioctl(me->fd, (int)IOCTL_MEI_NOTIFY_GET, &notification);
 	me->last_err = errno;
 	return rc == -1 ? -me->last_err : 0;
 }


### PR DESCRIPTION
musl's ioctl request macros (_IOC) expand to unsigned long values, causing sign-conversion warnings when passed to ioctl() which expects an int as the request parameter.

This issue occurs when building with -Werror -Wsign-conversion flags on musl-based systems, causing compilation failures.

Cast the IOCTL_MEI_* macros explicitly to int in three locations:
- IOCTL_MEI_CONNECT_CLIENT in __mei_connect()
- IOCTL_MEI_CONNECT_CLIENT_VTAG in __mei_connect_vtag()
- IOCTL_MEI_NOTIFY_GET in __mei_notify_get()

This maintains compatibility with both glibc (where _IOC expands to int) and musl (where it expands to unsigned long).